### PR TITLE
Initial commit: Create Template custom Widget project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include ipywidgetexample/static *.*

--- a/ipywidgetexample/__init__.py
+++ b/ipywidgetexample/__init__.py
@@ -1,0 +1,11 @@
+from ._version import version_info, __version__
+
+from .example import *
+
+def _jupyter_nbextension_paths():
+    return [{
+        'section': 'notebook',
+        'src': 'static',
+        'dest': 'jupyter-widget-example',
+        'require': 'jupyter-widget-example/extension'
+    }]

--- a/ipywidgetexample/_version.py
+++ b/ipywidgetexample/_version.py
@@ -1,0 +1,2 @@
+version_info = (0, 1, 0, 'dev')
+__version__ = '.'.join(map(str, version_info))

--- a/ipywidgetexample/example.py
+++ b/ipywidgetexample/example.py
@@ -1,0 +1,12 @@
+import ipywidgets as widgets
+from traitlets import Unicode
+
+
+class HelloWorld(widgets.DOMWidget):
+    """
+    """
+    _view_name = Unicode('HelloView').tag(sync=True)
+    _model_name = Unicode('HelloModel').tag(sync=True)
+    _view_module = Unicode('jupyter-widget-example').tag(sync=True)
+    _model_module = Unicode('jupyter-widget-example').tag(sync=True)
+    value = Unicode('Hello World!').tag(sync=True)

--- a/js/README.md
+++ b/js/README.md
@@ -1,0 +1,15 @@
+Jupyter Widget Example
+======================
+
+This package contains the javascript for the example jupyter custom widget. It
+is meant to serve as a template for custom widget authors.
+
+Package Install
+---------------
+
+**Prerequisites**
+- [node](http://nodejs.org/)
+
+```bash
+npm install --save jupyter-widget-example
+```

--- a/js/package.json
+++ b/js/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "jupyter-widget-example",
+  "version": "0.1.0",
+  "description": "Example jupyter widget",
+  "author": "Jupyter Developement Team",
+  "license": "BSD",
+  "main": "src/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyter/jupyter-widget-example.git"
+  },
+  "scripts": {
+    "prepublish": "webpack",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "devDependencies": {
+    "json-loader": "^0.5.4",
+    "webpack": "^1.12.14"
+  },
+  "dependencies": {
+    "jupyter-js-widgets": "^1.1.1",
+    "underscore": "^1.8.3"
+  }
+}

--- a/js/src/embed.js
+++ b/js/src/embed.js
@@ -1,0 +1,9 @@
+// Entry point for the npmcdn bundle containing custom model definitions.
+//
+// It differs from the notebook bundle in that it does not need to define a
+// dynamic baseURL for the static assets and may load some css that would
+// already be loaded by the notebook otherwise.
+
+// Export everything from jupyter-widget-example and the npm package version number.
+module.exports = require('./jupyter-widget-example.js');
+module.exports['version'] = require('../package.json').version;

--- a/js/src/extension.js
+++ b/js/src/extension.js
@@ -1,0 +1,20 @@
+// This file contains the javascript that is run when the notebook is loaded.
+// It contains some requirejs configuration and the `load_ipython_extension`
+// which is required for any notebook extension.
+
+// Configure requirejs
+if (window.require) {
+    window.require.config({
+        map: {
+            "*" : {
+                "jupyter-widget-example": "nbextensions/jupyter-widget-example/index",
+                "jupyter-js-widgets": "nbextensions/jupyter-js-widgets/extension"
+            }
+        }
+    });
+}
+
+// Export the required load_ipython_extention
+module.exports = {
+    load_ipython_extension: function() {}
+};

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1,0 +1,13 @@
+// Entry point for the notebook bundle containing custom model definitions.
+//
+// Setup notebook base URL
+//
+// Some static assets may be required by the custom widget javascript. The base
+// url for the notebook is not known at build time and is therefore computed
+// dynamically.
+__webpack_public_path__ = document.querySelector('body').getAttribute('data-base-url') + 'nbextensions/jupyter-widget-example/';
+
+
+// Export everything from jupyter-widget-example and the npm package version number.
+module.exports = require('./jupyter-widget-example.js');
+module.exports['version'] = require('../package.json').version;

--- a/js/src/jupyter-widget-example.js
+++ b/js/src/jupyter-widget-example.js
@@ -1,0 +1,38 @@
+var widgets = require('jupyter-js-widgets');
+var _ = require('underscore');
+
+
+// Custom Model. Custom widgets models must at least provide default values
+// for model attributes, including `_model_name`, `_view_name`, `_model_module`
+// and `_view_module` when different from the base class.
+//
+// When serialiazing entire widget state for embedding, only values different from the
+// defaults will be specified.
+var HelloModel = widgets.DOMWidgetModel.extend({
+    defaults: _.extend({}, widgets.DOMWidgetModel.prototype.defaults, {
+        _model_name : 'HelloModel',
+        _view_name : 'HelloView',
+        _model_module : 'jupyter-widget-example',
+        _view_module : 'jupyter-widget-example',
+        value : 'Hello World'
+    })
+});
+
+
+// Custom View. Renders the widget model.
+var HelloView = widgets.DOMWidgetView.extend({
+    render: function() {
+        this.value_changed();
+        this.model.on('change:value', this.value_changed, this);
+    },
+
+    value_changed: function() {
+        this.el.textContent = this.model.get('value');
+    }
+});
+
+
+module.exports = {
+    HelloModel : HelloModel,
+    HelloView : HelloView
+};

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -1,0 +1,71 @@
+var version = require('./package.json').version;
+
+// Custom webpack loaders are generally the same for all webpack bundles, hence
+// stored in a separate local variable.
+var loaders = [
+    { test: /\.json$/, loader: 'json-loader' },
+];
+
+
+module.exports = [
+    {// Notebook extension
+     //
+     // This bundle only contains the part of the JavaScript that is run on
+     // load of the notebook. This section generally only performs
+     // some configuration for requirejs, and provides the legacy
+     // "load_ipython_extension" function which is required for any notebook
+     // extension.
+     //
+        entry: './src/extension.js',
+        output: {
+            filename: 'extension.js',
+            path: '../ipywidgetexample/static',
+            libraryTarget: 'amd'
+        }
+    },
+    {// Bundle for the notebook containing the custom widget views and models
+     //
+     // This bundle contains the implementation for the custom widget views and
+     // custom widget.
+     // It must be an amd module
+     //
+        entry: './src/index.js',
+        output: {
+            filename: 'index.js',
+            path: '../ipywidgetexample/static',
+            libraryTarget: 'amd'
+        },
+        devtool: 'source-map',
+        module: {
+            loaders: loaders
+        },
+        externals: ['jupyter-js-widgets']
+    },
+    {// Embeddable jupyter-widget-example bundle
+     //
+     // This bundle is generally almost identical to the notebook bundle
+     // containing the custom widget views and models.
+     //
+     // The only difference is in the configuration of the webpack public path
+     // for the static assets.
+     //
+     // It will be automatically distributed by npmcdn to work with the static
+     // widget embedder.
+     //
+     // The target bundle is always `dist/index.js`, which is the path required
+     // by the custom widget embedder.
+     //
+        entry: './src/embed.js',
+        output: {
+            filename: 'index.js',
+            path: './dist/',
+            libraryTarget: 'amd',
+            publicPath: 'https://npmcdn.com/jupyter-widget-example@' + version + '/dist/'
+        },
+        devtool: 'source-map',
+        module: {
+            loaders: loaders
+        },
+        externals: ['jupyter-js-widgets']
+    }
+];

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,168 @@
+from __future__ import print_function
+from setuptools import setup, find_packages, Command
+from setuptools.command.sdist import sdist
+from setuptools.command.build_py import build_py
+from setuptools.command.egg_info import egg_info
+from subprocess import check_call
+import os
+import sys
+import platform
+
+here = os.path.dirname(os.path.abspath(__file__))
+node_root = os.path.join(here, 'js')
+is_repo = os.path.exists(os.path.join(here, '.git'))
+
+npm_path = os.pathsep.join([
+    os.path.join(node_root, 'node_modules', '.bin'),
+                os.environ.get('PATH', os.defpath),
+])
+
+from distutils import log
+log.set_verbosity(log.DEBUG)
+log.info('setup.py entered')
+log.info('$PATH=%s' % os.environ['PATH'])
+
+LONG_DESCRIPTION = 'Example of custom Jupyter widget library'
+
+def js_prerelease(command, strict=False):
+    """decorator for building minified js/css prior to another command"""
+    class DecoratedCommand(command):
+        def run(self):
+            jsdeps = self.distribution.get_command_obj('jsdeps')
+            if not is_repo and all(os.path.exists(t) for t in jsdeps.targets):
+                # sdist, nothing to do
+                command.run(self)
+                return
+
+            try:
+                self.distribution.run_command('jsdeps')
+            except Exception as e:
+                missing = [t for t in jsdeps.targets if not os.path.exists(t)]
+                if strict or missing:
+                    log.warn('rebuilding js and css failed')
+                    if missing:
+                        log.error('missing files: %s' % missing)
+                    raise e
+                else:
+                    log.warn('rebuilding js and css failed (not a problem)')
+                    log.warn(str(e))
+            command.run(self)
+            update_package_data(self.distribution)
+    return DecoratedCommand
+
+def update_package_data(distribution):
+    """update package_data to catch changes during setup"""
+    build_py = distribution.get_command_obj('build_py')
+    # distribution.package_data = find_package_data()
+    # re-init build_py options which load package_data
+    build_py.finalize_options()
+
+
+class NPM(Command):
+    description = 'install package.json dependencies using npm'
+
+    user_options = []
+
+    node_modules = os.path.join(node_root, 'node_modules')
+
+    targets = [
+        os.path.join(here, 'ipywidgetexample', 'static', 'extension.js'),
+        os.path.join(here, 'ipywidgetexample', 'static', 'index.js')
+    ]
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def has_npm(self):
+        try:
+            check_call(['npm', '--version'])
+            return True
+        except:
+            return False
+
+    def should_run_npm_install(self):
+        package_json = os.path.join(node_root, 'package.json')
+        node_modules_exists = os.path.exists(self.node_modules)
+        return self.has_npm()
+
+    def run(self):
+        has_npm = self.has_npm()
+        if not has_npm:
+            log.error("`npm` unavailable.  If you're running this command using sudo, make sure `npm` is available to sudo")
+
+        env = os.environ.copy()
+        env['PATH'] = npm_path
+
+        if self.should_run_npm_install():
+            log.info("Installing build dependencies with npm.  This may take a while...")
+            check_call(['npm', 'install'], cwd=node_root, stdout=sys.stdout, stderr=sys.stderr)
+            os.utime(self.node_modules, None)
+
+        for t in self.targets:
+            if not os.path.exists(t):
+                msg = 'Missing file: %s' % t
+                if not has_npm:
+                    msg += '\nnpm is required to build a development version of widgetsnbextension'
+                raise ValueError(msg)
+
+        # update package data in case this created new files
+        update_package_data(self.distribution)
+
+version_ns = {}
+with open(os.path.join(here, 'ipywidgetexample', '_version.py')) as f:
+    exec(f.read(), {}, version_ns)
+
+setup_args = {
+    'name': 'ipywidgetexample',
+    'version': version_ns['__version__'],
+    'description': 'Example of custom Jupyter widget library',
+    'long_description': LONG_DESCRIPTION,
+    'License': 'BSD',
+    'include_package_data': True,
+    'data_files': [
+        ('share/jupyter/nbextensions/jupyter-widget-example', [
+            'ipywidgetexample/static/extension.js',
+            'ipywidgetexample/static/index.js',
+            'ipywidgetexample/static/index.js.map',
+        ]),
+    ],
+    'install_requires': [
+        'ipywidgets>=5.1.3',
+        'numpy',
+        'pandas'],
+    'packages': find_packages(),
+    'zip_safe': False,
+    'cmdclass': {
+        'build_py': js_prerelease(build_py),
+        'egg_info': js_prerelease(egg_info),
+        'sdist': js_prerelease(sdist, strict=True),
+        'jsdeps': NPM,
+    },
+
+    'author': 'Jupyter Development Team',
+    'author_email': 'jupyter@googlegroups.com',
+    'url': 'http://jupyter.org',
+    'license': 'BSD',
+    'keywords': [
+        'ipython',
+        'jupyter',
+        'widgets',
+    ],
+    'classifiers': [
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'Topic :: Multimedia :: Graphics',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+    ],
+}
+
+setup(**setup_args)


### PR DESCRIPTION
@willingc @jdfreder this is an example custom widget project meant to serve as a template for widget authors.

@minrk suggest we license this as `CC-0` instead of BSD. 

Other suggestion by Min: make a cookiecutter template for such a project.